### PR TITLE
Make changes needed to build with Qt5

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -21,7 +21,11 @@
  * Look at the README for more information on the program.
  */
 
-#include <QtGui/QApplication>
+#include <QtGui>
+#include <QApplication>
+#if QT_VERSION >= 0x050000
+#include <QtWidgets>
+#endif
 #include "xastir.h"
 
 int main(int argc, char *argv[])

--- a/mainwindow.h
+++ b/mainwindow.h
@@ -12,7 +12,6 @@
 
 #include <QtCore/QVariant>
 #include <QtGui/QAction>
-// #include <QtGui/QApplication>
 #include <QtGui>
 #include <QApplication>
 #include <QtGui/QButtonGroup>

--- a/mainwindow.h
+++ b/mainwindow.h
@@ -12,7 +12,9 @@
 
 #include <QtCore/QVariant>
 #include <QtGui/QAction>
-#include <QtGui/QApplication>
+// #include <QtGui/QApplication>
+#include <QtGui>
+#include <QApplication>
 #include <QtGui/QButtonGroup>
 #include <QtGui/QCheckBox>
 #include <QtGui/QDialogButtonBox>
@@ -31,7 +33,9 @@
 #include <QtGui/QToolButton>
 #include <QtGui/QVBoxLayout>
 #include <QtGui/QWidget>
-
+#if QT_VERSION >= 0x050000
+#include <QtWidgets>
+#endif
 QT_BEGIN_NAMESPACE
 
 class Ui_MainWindow

--- a/netinterface.cpp
+++ b/netinterface.cpp
@@ -164,7 +164,7 @@ void NetInterface::nowConnected()
     else {
         loginStr = "user " + callsign + " pass " + passcode + " vers XASTIR-QT 0.1 \r\n";
     }
-    tcpSocket.write( loginStr.toAscii().data() );
+    tcpSocket.write( loginStr.toLatin1().data() );
 
     // Update interface status
     deviceState = DEVICE_UP;

--- a/xastir-qt.pro
+++ b/xastir-qt.pro
@@ -4,6 +4,7 @@
 #
 #-------------------------------------------------
 
+greaterThan(QT_MAJOR_VERSION, 4): QT += widgets
 QT       += network
 
 TARGET = xastir-qt


### PR DESCRIPTION
Qt4 reached end-of-life in 2015, and many distros (including FreeBSD,
where I do most of my work) have dropped it from their package
systems.  The only way to get Qt4 on such systems is to build the
whole durned thing from source.  Better to make the code work in both.

This commit SHOULD let Xastir-qt build with either Qt4 or Qt5, but I
can only check that it works with Qt5 (it does).  I'll have to leave
it to the reviewers to test with Qt4.