### PR TITLE
Fix emacs config to match Xastir project

### DIFF
--- a/.dir-locals.el
+++ b/.dir-locals.el
@@ -1,4 +1,4 @@
-((nil . ((indent-tabs-mode . t)
+((nil . ((indent-tabs-mode . nil)
          (c-basic-offset . 4)
          (tab-width . 4))
       ))


### PR DESCRIPTION
Tom Russo checked in an update to the .dir-locals.el file (Emacs config file). Updating the Xastir-Qt one to match.